### PR TITLE
[pro-enterprise-1]cloud9集成(隐藏部分功能)

### DIFF
--- a/configs/default.js
+++ b/configs/default.js
@@ -86,7 +86,7 @@ var config = [
             "ext/themes/themes",
             "ext/themes_default/themes_default",
             "ext/panels/panels",
-            "ext/dockpanel/dockpanel",
+            "ext/dockpanel/dockpanel",                                                      //*
             "ext/openfiles/openfiles",
             "ext/tree/tree",
             "ext/save/save",
@@ -95,11 +95,11 @@ var config = [
             "ext/newresource/newresource",
             "ext/undo/undo",
             "ext/clipboard/clipboard",
-            "ext/searchinfiles/searchinfiles",
+            "ext/searchinfiles/searchinfiles",                                              //*
             "ext/searchreplace/searchreplace",
-            "ext/quickwatch/quickwatch",
+            "ext/quickwatch/quickwatch",                                                    //*
             "ext/gotoline/gotoline",
-            "ext/preview/preview",
+            // "ext/preview/preview",                                                          //*
             // "ext/deploy/deploy",
             //"ext/log/log",
             "ext/help/help",
@@ -113,12 +113,12 @@ var config = [
             //"ext/preview/preview",
             "ext/extmgr/extmgr",
             //"ext/run/run", //Add location rule
-            "ext/runpanel/runpanel", //Add location rule
-            "ext/debugger/debugger", //Add location rule
-            "ext/dbg-node/dbg-node",
+            // "ext/runpanel/runpanel", //Add location rule                                    //*
+            "ext/debugger/debugger", //Add location rule                                    //*
+            "ext/dbg-node/dbg-node",                                                        //*
             "ext/noderunner/noderunner", //Add location rule
             "ext/console/console",
-            "ext/consolehints/consolehints",
+            // "ext/consolehints/consolehints",                                                //*
             "ext/tabbehaviors/tabbehaviors",
             "ext/tabsessions/tabsessions",
             //"ext/keybindings/keybindings",
@@ -149,9 +149,9 @@ var config = [
             "ext/colorpicker/colorpicker",
             "ext/gitblame/gitblame",
             //"ext/githistory/githistory",
-            "ext/autosave/autosave",
-            "ext/revisions/revisions",
-            "ext/language/liveinspect",
+            "ext/autosave/autosave",                                                        //*
+            "ext/revisions/revisions",                                                      //*
+            "ext/language/liveinspect",                                                     //*
             "ext/splitview/splitview",
             "ext/terminal/terminal"
         ]

--- a/plugins-client/ext.console/console.js
+++ b/plugins-client/ext.console/console.js
@@ -21,7 +21,7 @@ var markup = require("text!ext/console/console.xml");
 var theme = require("text!ext/console/themes/arthur.css");
 var inputHistory = require("ext/console/input_history");
 var anims = require("ext/anims/anims");
-var preview = require("ext/preview/preview");
+// var preview = require("ext/preview/preview");
 
 // Some constants used throughout the plugin
 var KEY_TAB = 9, KEY_CR = 13, KEY_UP = 38, KEY_ESC = 27, KEY_DOWN = 40;
@@ -388,7 +388,7 @@ module.exports = ext.register("ext/console/console", {
 
             var page = apf.findHost(pNode.parentNode.parentNode);
             if (page && page.id !== "pgOutput")
-                page.setCaption("Console");
+                // page.setCaption("Console");
 
             if (pNode.className.indexOf("quitting") !== -1)
                 apf.setStyleClass(pNode, "quit_proc", ["quitting_proc"]);
@@ -449,7 +449,7 @@ module.exports = ext.register("ext/console/console", {
         if ((lang = /^(\w+)-start$/.exec(message.type)) && runners.indexOf(lang[1]) >= 0) {
             var clearOnRun = settings.model.queryValue("auto/console/@clearonrun");
             if (apf.isTrue(clearOnRun) && window["txtOutput"])
-                txtOutput.clear();
+                // txtOutput.clear();
 
             this.createProcessLog(message.pid, lang[1]);
             return;
@@ -811,7 +811,7 @@ module.exports = ext.register("ext/console/console", {
                 txtConsoleInput.focus();
         }
 
-        tabConsole.addEventListener("afterrender", function() {
+        /*tabConsole.addEventListener("afterrender", function() {
             txtOutput.addEventListener("keydown", kdHandler);
             txtConsole.addEventListener("keydown", kdHandler);
 
@@ -840,7 +840,7 @@ module.exports = ext.register("ext/console/console", {
             setTimeout(function(){
                 txtConsoleInput.focus();
             });
-        });
+        });*/
 
         this.splitter = winDbgConsole.parentNode.$handle;
         this.splitter.addEventListener("dragdrop", function(e){
@@ -851,7 +851,7 @@ module.exports = ext.register("ext/console/console", {
         this.nodes.push(winDbgConsole);
 
 
-        txtConsoleInput.ace.commands.bindKeys({
+        /*txtConsoleInput.ace.commands.bindKeys({
             "up": function(input) {input.setValue(_self.cliInputHistory.getPrev(), 1);},
             "down": function(input) {input.setValue(_self.cliInputHistory.getNext(), 1);},
             "Return": function(input) {
@@ -862,7 +862,7 @@ module.exports = ext.register("ext/console/console", {
                 input.setValue("");
                 txtConsole.$container.scrollTop = txtConsole.$container.scrollHeight;
             }
-        });
+        });*/
 
         if (this.logged.length) {
             this.logged.forEach(function(text){
@@ -908,7 +908,7 @@ module.exports = ext.register("ext/console/console", {
 
     newtab : function() {
         var c9shell = tabConsole.add("Console");
-        c9shell.setAttribute("class", "pgConsole");
+        // c9shell.setAttribute("class", "pgConsole");
         c9shell.setAttribute("closebtn", true);
         var c9shellText = c9shell.appendChild(new apf.text({
             margin     : "3 0 0 0",

--- a/plugins-client/ext.console/console.xml
+++ b/plugins-client/ext.console/console.xml
@@ -4,12 +4,12 @@
             <a:tab id="tabConsole" skin="tab_console" visible="false" render2="runtime" buttons="scale,order"
               onclose="return require('ext/console/console').checkIfPageCanClose(event)">
                 <a:hbox pack="end" top="2" right="3" height="24" align="center" padding="0">
-                    <a:button id="btnConsoleClear" skin="btn_icon_only" icon="console_clear.png" margin="2 2 0 0"
+                    <!--<a:button id="btnConsoleClear" skin="btn_icon_only" icon="console_clear.png" margin="2 2 0 0"
                       onclick  = "require('ext/console/console').clear();this.blur();" />
                     <a:button id="btnConsoleSettings" skin="btn_icon_only"
                       icon    = "console_settings.png"
                       margin  = "2 4 0 0"
-                      submenu = "mnuConsoleSettings" />
+                      submenu = "mnuConsoleSettings" />-->
                     <a:button id="btnConsoleMax" skin="btn_icon_only" icon="console_max.png" state="true" margin="2 2 0 0"
                       onclick = "
                         var console = require('ext/console/console');
@@ -32,7 +32,7 @@
                         this.blur();
                       "/>
                 </a:hbox>
-                <a:page id="pgConsole" caption="Console" name="console" class="pgConsole">
+                <!--<a:page id="pgConsole" caption="Console" name="console" class="pgConsole">
                     <a:text id="txtConsole"
                       margin     = "3 0 0 0"
                       anchors    = "0 17 0 0"
@@ -65,7 +65,7 @@
                       bottom = "0"
                       skin   = "console_scrollbar"
                       width  = "17" />
-                </a:page>
+                </a:page>-->
                 <a:page id="pgTerminal" caption="Terminal" name="terminal" class="pgTerminal">
                     <a:button id="newTerminalBtn" skin="btn_icon_only" icon="console_new_terminal.png" margin="2 2 0 0" class="newTerminalBtn" onclick = "this.blur();"/>
                     <div id="terminalWindow" canSelect="true"></div>
@@ -73,7 +73,7 @@
             </a:tab>
 
             <a:hbox id="cliBox" class="consoleInputBox" edge="1 1 2 1" padding="0" pack="end" visible="false" height="31">
-                <a:text id="txtConsolePrompt"
+                <!--<a:text id="txtConsolePrompt"
                     class="txt_console_prompt"
                     visible="false"
                     value="" />
@@ -81,7 +81,7 @@
                   initial-message = 'Type "help" to get a list of commands'
                   margin          = "2 1 1 5"
                   skin            = "tb_console"
-                  flex            = "1" />
+                  flex            = "1" />-->
                 <a:button id="btnCollapseConsole" skin="btn_console_open" icon="switch.png" state="true" height="27"
                     value = "{!!tabConsole.visible}"
                     onprop.value="
@@ -90,7 +90,7 @@
                       var settings = require('core/settings');
                       try { console[event.value ? 'show' : 'hide'](); } catch(e) {}
                       if(event.value == true &amp;&amp; termElement.classList.contains('curbtn') == true &amp;&amp; settings.model.queryValue('auto/console/@showinput') == 'true') {
-                        console.hideInput();
+                        /*console.hideInput();*/
                         settings.model.setQueryValue('auto/console/@showinput', true);
                       }
                     "/>

--- a/plugins-server/cloud9.core/view/ide.tmpl.html
+++ b/plugins-server/cloud9.core/view/ide.tmpl.html
@@ -36,7 +36,7 @@
                 var footer = document.createElement("div");
                 footer.className = "footer";
                 // yes this is bad
-                footer.innerHTML = '<a href="https://github.com/exsilium/cloud9/wiki">Documentation</a> | <a href="https://github.com/exsilium/cloud9/issues">Support</a>';
+                footer.innerHTML = '<a href="https://www.apemesh.com">Documentation</a> | <a href="https://www.apemesh.com">Support</a>';
                 
                 var content = document.createElement("div");
                 content.className = "loading-progress";


### PR DESCRIPTION
1. 隐藏了顶级菜单的"Preview"和"Debug / Run"菜单
2. 隐藏了左侧菜单的与debug/run功能相关的图标
3. 隐藏了底部控制台部分的"Console"和"Output"功能区
4. 修改了首页模版加载时右下角"Documentation"和"Support"的链接地址